### PR TITLE
Hook implmentations are generators

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Pylint" enabled="true" level="TYPO" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_16" project-jdk-name="Python 3.8 (venv)" project-jdk-type="Python SDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/nbgitpuller-downloader-plugins.iml" filepath="$PROJECT_DIR$/.idea/nbgitpuller-downloader-plugins.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/nbgitpuller-downloader-plugins.iml
+++ b/.idea/nbgitpuller-downloader-plugins.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,8 @@
+[FORMAT]
+max-line-length=150
+good-names=i,j,k,ex,x,y
+
+[MASTER]
+disable=
+    C0114, # missing-module-docstring
+

--- a/README.md
+++ b/README.md
@@ -17,15 +17,6 @@ This plugin expects URLs included in the nbgitpuller link to be in the following
 
 In all of these cases, the archive must be publicly available or "shared" with everyone in the case of Google Drive.
 
-## Plugin Development Notes
-Please note, that any nbgitpuller-downloader-plugin needs to have the following import and call:
-```
-import nest_asyncio
-nest_asyncio.apply()
-```
-This is needed to nest the async calls for your downloader-plugin into the current event loop being used in
-nbgitpuller. The three plugin's in this repo provide an example of the implementation.
-
 ## Installation
 
 ```shell

--- a/src/nbgitpuller_downloader_dropbox/dropbox_downloader.py
+++ b/src/nbgitpuller_downloader_dropbox/dropbox_downloader.py
@@ -3,15 +3,14 @@ from nbgitpuller_downloader_plugins_util.plugin_helper import HandleFilesHelper
 
 
 @hookimpl
-def handle_files(helper_args, query_line_args):
+def handle_files(repo_parent_dir, other_kw_args):
     """
-    :param dict helper_args: the function, helper_args["progress_func"], that writes messages to
-    the progress stream in the browser window and the download_q, helper_args["download_q"] the progress function uses.
-    :param dict query_line_args: this includes all the arguments included on the nbgitpuller URL
+    :param str repo_parent_dir: the directory where the archive is downloaded to
+    :param dict other_kw_args: this includes all the arguments included on the nbgitpuller URL or passed via CLI
     :return two parameter json unzip_dir and origin_repo_path
     :rtype json object
     """
-    query_line_args["repo"] = query_line_args["repo"].replace("dl=0", "dl=1")  # dropbox: download set to 1
-    hfh = HandleFilesHelper(helper_args, query_line_args)
+    other_kw_args["repo"] = other_kw_args["repo"].replace("dl=0", "dl=1")  # dropbox: download set to 1
+    hfh = HandleFilesHelper(repo_parent_dir, other_kw_args)
     output_info = yield from hfh.handle_files_helper()
-    helper_args["handle_files_output"] = output_info
+    other_kw_args["handle_files_output"] = output_info

--- a/src/nbgitpuller_downloader_dropbox/dropbox_downloader.py
+++ b/src/nbgitpuller_downloader_dropbox/dropbox_downloader.py
@@ -1,16 +1,9 @@
 import asyncio
-import nest_asyncio
 from nbgitpuller.plugin_hook_specs import hookimpl
 from nbgitpuller_downloader_plugins_util.plugin_helper import HandleFilesHelper
 
-
-# this allows us to nest usage of the event_loop from asyncio
-# being used by tornado in jupyter distro
-# Ref: https://medium.com/@vyshali.enukonda/how-to-get-around-runtimeerror-this-event-loop-is-already-running-3f26f67e762e
-nest_asyncio.apply()
-
 @hookimpl
-def handle_files(helper_args, query_line_args):
+async def handle_files(helper_args, query_line_args):
     """
     :param dict helper_args: the function, helper_args["progress_func"], that writes messages to
     the progress stream in the browser window and the download_q, helper_args["download_q"] the progress function uses.
@@ -19,8 +12,6 @@ def handle_files(helper_args, query_line_args):
     :rtype json object
     """
     query_line_args["repo"] = query_line_args["repo"].replace("dl=0", "dl=1")  # dropbox: download set to 1
-    loop = asyncio.get_event_loop()
     hfh = HandleFilesHelper(helper_args, query_line_args)
-    tasks = hfh.handle_files_helper(), helper_args["wait_for_sync_progress_queue"]()
-    result_handle, _ = loop.run_until_complete(asyncio.gather(*tasks))
+    result_handle, _ = await asyncio.gather(hfh.handle_files_helper(), helper_args["wait_for_sync_progress_queue"]())
     return result_handle

--- a/src/nbgitpuller_downloader_dropbox/dropbox_downloader.py
+++ b/src/nbgitpuller_downloader_dropbox/dropbox_downloader.py
@@ -1,9 +1,9 @@
-import asyncio
 from nbgitpuller.plugin_hook_specs import hookimpl
 from nbgitpuller_downloader_plugins_util.plugin_helper import HandleFilesHelper
 
+
 @hookimpl
-async def handle_files(helper_args, query_line_args):
+def handle_files(helper_args, query_line_args):
     """
     :param dict helper_args: the function, helper_args["progress_func"], that writes messages to
     the progress stream in the browser window and the download_q, helper_args["download_q"] the progress function uses.
@@ -13,5 +13,5 @@ async def handle_files(helper_args, query_line_args):
     """
     query_line_args["repo"] = query_line_args["repo"].replace("dl=0", "dl=1")  # dropbox: download set to 1
     hfh = HandleFilesHelper(helper_args, query_line_args)
-    result_handle, _ = await asyncio.gather(hfh.handle_files_helper(), helper_args["wait_for_sync_progress_queue"]())
-    return result_handle
+    output_info = yield from hfh.handle_files_helper()
+    helper_args["handle_files_output"] = output_info

--- a/src/nbgitpuller_downloader_generic_web/generic_web_downloader.py
+++ b/src/nbgitpuller_downloader_generic_web/generic_web_downloader.py
@@ -3,16 +3,15 @@ from nbgitpuller_downloader_plugins_util.plugin_helper import HandleFilesHelper
 
 
 @hookimpl
-def handle_files(helper_args, query_line_args):
+def handle_files(repo_parent_dir, other_kw_args):
     """
     This begins the event loop that will both download the compressed archive and send messages
     about the progress of the download to the UI.
-    :param dict helper_args: the function, helper_args["progress_func"], that writes messages to
-    the progress stream in the browser window and the download_q, helper_args["download_q"] the progress function uses.
-    :param dict query_line_args: this includes all the arguments included on the nbgitpuller URL
+    :param str repo_parent_dir: the directory where the archive is downloaded to
+    :param dict other_kw_args: this includes all the arguments included on the nbgitpuller URL or passed via CLI
     :return two parameter json unzip_dir and origin_repo_path
     :rtype json object
     """
-    hfh = HandleFilesHelper(helper_args, query_line_args)
+    hfh = HandleFilesHelper(repo_parent_dir, other_kw_args)
     output_info = yield from hfh.handle_files_helper()
-    helper_args["handle_files_output"] = output_info
+    other_kw_args["handle_files_output"] = output_info

--- a/src/nbgitpuller_downloader_generic_web/generic_web_downloader.py
+++ b/src/nbgitpuller_downloader_generic_web/generic_web_downloader.py
@@ -1,9 +1,9 @@
-import asyncio
 from nbgitpuller.plugin_hook_specs import hookimpl
 from nbgitpuller_downloader_plugins_util.plugin_helper import HandleFilesHelper
 
+
 @hookimpl
-async def handle_files(helper_args, query_line_args):
+def handle_files(helper_args, query_line_args):
     """
     This begins the event loop that will both download the compressed archive and send messages
     about the progress of the download to the UI.
@@ -14,5 +14,5 @@ async def handle_files(helper_args, query_line_args):
     :rtype json object
     """
     hfh = HandleFilesHelper(helper_args, query_line_args)
-    result_handle, _ = await asyncio.gather(hfh.handle_files_helper(), helper_args["wait_for_sync_progress_queue"]())
-    return result_handle
+    output_info = yield from hfh.handle_files_helper()
+    helper_args["handle_files_output"] = output_info

--- a/src/nbgitpuller_downloader_generic_web/generic_web_downloader.py
+++ b/src/nbgitpuller_downloader_generic_web/generic_web_downloader.py
@@ -1,16 +1,9 @@
 import asyncio
-import nest_asyncio
 from nbgitpuller.plugin_hook_specs import hookimpl
 from nbgitpuller_downloader_plugins_util.plugin_helper import HandleFilesHelper
 
-
-# this allows us to nest usage of the event_loop from asyncio
-# being used by tornado in jupyter distro
-# Ref: https://medium.com/@vyshali.enukonda/how-to-get-around-runtimeerror-this-event-loop-is-already-running-3f26f67e762e
-nest_asyncio.apply()
-
 @hookimpl
-def handle_files(helper_args, query_line_args):
+async def handle_files(helper_args, query_line_args):
     """
     This begins the event loop that will both download the compressed archive and send messages
     about the progress of the download to the UI.
@@ -20,9 +13,6 @@ def handle_files(helper_args, query_line_args):
     :return two parameter json unzip_dir and origin_repo_path
     :rtype json object
     """
-    loop = asyncio.get_event_loop()
     hfh = HandleFilesHelper(helper_args, query_line_args)
-    tasks = hfh.handle_files_helper(), helper_args["wait_for_sync_progress_queue"]()
-    result_handle, _ = loop.run_until_complete(asyncio.gather(*tasks))
-
+    result_handle, _ = await asyncio.gather(hfh.handle_files_helper(), helper_args["wait_for_sync_progress_queue"]())
     return result_handle

--- a/src/nbgitpuller_downloader_googledrive/googledrive_downloader.py
+++ b/src/nbgitpuller_downloader_googledrive/googledrive_downloader.py
@@ -1,6 +1,5 @@
 import re
-import asyncio
-import aiohttp
+import requests
 from nbgitpuller.plugin_hook_specs import hookimpl
 from nbgitpuller_downloader_plugins_util.plugin_helper import HandleFilesHelper
 
@@ -8,7 +7,7 @@ DOWNLOAD_URL = "https://docs.google.com/uc?export=download"
 
 
 @hookimpl
-async def handle_files(helper_args, query_line_args):
+def handle_files(helper_args, query_line_args):
     """
     This function calls nbgitpuller's handle_files_helper after first determining the
     file extension(e.g. zip, tar.gz, etc). Google Drive does not use the name of the file to
@@ -22,16 +21,16 @@ async def handle_files(helper_args, query_line_args):
     :rtype json object
     """
     repo = query_line_args["repo"]
-    helper_args["download_q"].put_nowait("Determining type of archive...\n")
-    response = await get_response_from_drive(DOWNLOAD_URL, get_id(repo))
+    yield "Determining type of archive...\n"
+    response = get_response_from_drive(DOWNLOAD_URL, get_id(repo))
     ext = determine_file_extension_from_response(response)
-    helper_args["download_q"].put_nowait(f"Archive is: {ext}\n")
+    yield f"Archive is: {ext}\n"
     helper_args["extension"] = ext
     helper_args["download_func"] = download_archive_for_google
 
     hfh = HandleFilesHelper(helper_args, query_line_args)
-    result_handle, _ = await asyncio.gather(hfh.handle_files_helper(), helper_args["wait_for_sync_progress_queue"]())
-    return result_handle
+    output_info = yield from hfh.handle_files_helper()
+    helper_args["handle_files_output"] = output_info
 
 
 def get_id(repo):
@@ -47,24 +46,23 @@ def get_id(repo):
     return repo[start_id_index:end_id_index]
 
 
-def get_confirm_token(session, url):
+def get_confirm_token(session):
     """
     Google may include a confirm dialog if the file is too big. This retreives the
     confirmation token and uses it to complete the download.
 
-    :param aiohttp.ClientSession session: used to the get the cookies from the reponse
-    :param aiohttp.URL url : the url is used to filter out the correct cookies from the session
+    :param requests.Session session: used to the get the cookies from the reponse
     :return the cookie if found or None if not found
     :rtype str
     """
-    cookies = session.cookie_jar.filter_cookies(url)
+    cookies = session.cookies
     for key, cookie in cookies.items():
         if key.startswith('download_warning'):
             return cookie
     return None
 
 
-async def download_archive_for_google(repo=None, temp_download_file=None):
+def download_archive_for_google(repo=None, temp_download_file=None):
     """
     This requests the file from the repo(url) given and saves it to the disk. This is executed
     in plugin_helper.py and note that the parameters to this function are the same as the standard
@@ -77,30 +75,26 @@ async def download_archive_for_google(repo=None, temp_download_file=None):
     yield "Downloading archive ...\n"
     try:
         file_id = get_id(repo)
-        chunk_size = 1024
-        async with aiohttp.ClientSession() as session:
-            async with session.get(DOWNLOAD_URL, params={'id': file_id}) as response:
-                token = get_confirm_token(session, repo)
+        with requests.Session() as session:
+            with session.get(DOWNLOAD_URL, params={'id': file_id}) as response:
+                token = get_confirm_token(session)
                 if token:
                     params = {'id': file_id, 'confirm': token}
-                    response = await session.get(repo, params=params)
-                with open(temp_download_file, 'ab') as file_handle:
+                    response = session.get(DOWNLOAD_URL, params=params)
+                with open(temp_download_file, 'ab') as f:
                     count_chunks = 1
-                    while True:
-                        count_chunks += 1
-                        if count_chunks % 1000 == 0:
-                            display = count_chunks / 1000
-                            yield f"Downloading Progress ... {display}MB\n"
-                        chunk = await response.content.read(chunk_size)
-                        if not chunk:
-                            break
-                        file_handle.write(chunk)
+                    for chunk in response.iter_content(chunk_size=1024):
+                        if chunk:
+                            count_chunks += 1
+                            if count_chunks % 1000 == 0:
+                                display = count_chunks / 1000
+                                yield f"Downloading Progress ... {display}MB\n"
+                            f.write(chunk)
         yield "Archive Downloaded....\n"
     except Exception as ex:
         raise ex
 
-
-async def get_response_from_drive(url, file_id):
+def get_response_from_drive(url, file_id):
     """
     You need to check to see that Google Drive has not asked the
     request to confirm that they disabled the virus scan on files that
@@ -114,12 +108,12 @@ async def get_response_from_drive(url, file_id):
     :return response object
     :rtype json object
     """
-    async with aiohttp.ClientSession() as session:
-        async with session.get(url, params={'id': file_id}) as response:
-            token = get_confirm_token(session, url)
+    with requests.Session() as session:
+        with session.get(url, params={'id': file_id}) as response:
+            token = get_confirm_token(session)
             if token:
                 params = {'id': file_id, 'confirm': token}
-                response = await session.get(url, params=params)
+                response = session.get(url, params=params)
                 return response
             return response
 
@@ -127,16 +121,16 @@ async def get_response_from_drive(url, file_id):
 def determine_file_extension_from_response(response):
     """
     This retrieves the file extension from the response.
-    :param aiohttp.ClientResponse response: the response object from the download
+    :param requests.Response response: the response object from the download
     :return the extension indicating the file compression(e.g. zip, tgz)
     :rtype str
     """
     content_disposition = response.headers.get('content-disposition')
     ext = None
     if content_disposition:
-        fname = re.findall("filename\\*?=([^;]+)", content_disposition)
-        fname = fname[0].strip().strip('"')
-        ext = fname.split(".")[1]
+        file_name = re.findall("filename\\*?=([^;]+)", content_disposition)
+        file_name = file_name[0].strip().strip('"')
+        ext = file_name.split(".")[1]
 
     if ext is None:
         message = f"Could not determine compression type of: {content_disposition}"

--- a/src/nbgitpuller_downloader_googledrive/googledrive_downloader.py
+++ b/src/nbgitpuller_downloader_googledrive/googledrive_downloader.py
@@ -7,30 +7,29 @@ DOWNLOAD_URL = "https://docs.google.com/uc?export=download"
 
 
 @hookimpl
-def handle_files(helper_args, query_line_args):
+def handle_files(repo_parent_dir, other_kw_args):
     """
     This function calls nbgitpuller's handle_files_helper after first determining the
     file extension(e.g. zip, tar.gz, etc). Google Drive does not use the name of the file to
     identify the file on the URL so we must download the file first to get the extension from the
     response, set up a specialized download function and parameters and then pass off handling
     to nbgitpuller.
-    :param dict helper_args: the function, helper_args["progress_func"], that writes messages to
-    the progress stream in the browser window and the download_q, helper_args["download_q"] the progress function uses.
-    :param dict query_line_args: this includes all the arguments included on the nbgitpuller URL
+    :param str repo_parent_dir: the directory where the archive is downloaded to
+    :param dict other_kw_args: this includes all the arguments included on the nbgitpuller URL or passed via CLI
     :return two parameter json output_dir and origin_repo_path
     :rtype json object
     """
-    repo = query_line_args["repo"]
+    repo = other_kw_args["repo"]
     yield "Determining type of archive...\n"
     response = get_response_from_drive(DOWNLOAD_URL, get_id(repo))
     ext = determine_file_extension_from_response(response)
     yield f"Archive is: {ext}\n"
-    helper_args["extension"] = ext
-    helper_args["download_func"] = download_archive_for_google
+    other_kw_args["extension"] = ext
+    other_kw_args["download_func"] = download_archive_for_google
 
-    hfh = HandleFilesHelper(helper_args, query_line_args)
+    hfh = HandleFilesHelper(repo_parent_dir, other_kw_args)
     output_info = yield from hfh.handle_files_helper()
-    helper_args["handle_files_output"] = output_info
+    other_kw_args["handle_files_output"] = output_info
 
 
 def get_id(repo):


### PR DESCRIPTION
This PR combines three commits:
- removing the nest_asyncio library and functionality
- simplifying of the handle_files signature after converting the hookimpl's to generators